### PR TITLE
Setting nitpicky=False in conf.py

### DIFF
--- a/{{cookiecutter.directory_name}}/docs/conf.py
+++ b/{{cookiecutter.directory_name}}/docs/conf.py
@@ -376,7 +376,7 @@ templates_path = ['_templates']
 # want to store them locally.
 suppress_warnings = ['image.nonlocal_uri']
 
-nitpicky = True
+nitpicky = False
 
 
 # we allow most types from the typing modules to be used in


### PR DESCRIPTION
As the documentation build of the CI may fail if someone uses this cookiecut and setup the CI in a repository, this change is made to prevent such an issue.